### PR TITLE
Fix ValueError parsing datetime

### DIFF
--- a/gilts.py
+++ b/gilts.py
@@ -49,10 +49,10 @@ with open(sys.argv[1], 'r') as f:
     for row in csv_reader:
         # Parse out all relevant data from the record.
         gilt_name = row[0]
-        export_date = datetime.strptime(row[1], "%d/%m/%Y").date()
+        export_date = datetime.strptime(row[1], "%m/%d/%Y").date()
         type = SecurityToType[row[3]]
         coupon = float(row[4]) if row[4] != "N/A" else 0
-        maturity_date = datetime.strptime(row[5], "%d/%m/%Y").date()
+        maturity_date = datetime.strptime(row[5], "%m/%d/%Y").date()
         days_to_maturity = (maturity_date - export_date).days
         clean = float(row[6]) if row[6] != "N/A" else 100
         dirty = float(row[7]) if row[7] != "N/A" else clean


### PR DESCRIPTION
In the latest .csv downloaded from https://reports.tradeweb.com/closing-prices/gilts/, the format of datetimes has the months before the days (like in US locale), not sure if this is just me (I'm in the UK...) but I had to make this change in order to being able to run the script successfully.

Thanks for the useful little script, by the way!